### PR TITLE
Distribution over different Kubernetes clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ python examples/MINST_RAW_format/mnist_dataset_inference_example.py
 
 ### Requirements
 
-- [Python supported by Tensorflow 3.5–3.7](https://www.python.org/)
+- [Python 3.5-3.7, supported by Tensorflow](https://www.python.org/)
 - [Node.js](https://nodejs.org/)
 - [Docker](https://www.docker.com/)
 - [kubernetes>=v1.15.5](https://kubernetes.io/)

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,6 @@
 # pull official base image
-FROM tensorflow/tensorflow:2.0.1-py3
+# FROM tensorflow/tensorflow:2.0.1-py3
+FROM tensorflow/tensorflow:2.2.0
 # FROM python:3.7.7-slim-stretch # for Raspberry
 
 # set work directory

--- a/backend/automl/models.py
+++ b/backend/automl/models.py
@@ -92,6 +92,8 @@ class Inference(models.Model):
     time = models.DateTimeField(default=now, editable=False)
     limit = models.DecimalField(max_digits=15, decimal_places=10, blank=True,  null=True)
     output_upper = models.TextField(blank=True)
+    token = models.TextField(blank=True, default=None, null=True)
+    external_host = models.TextField(blank=True, default=None, null=True)
 
     class Meta(object):
         ordering = ('-time', )

--- a/backend/automl/serializers.py
+++ b/backend/automl/serializers.py
@@ -173,7 +173,7 @@ class DeployInferenceSerializer(serializers.ModelSerializer):
     
     class Meta:
         model = Inference
-        fields = ['model_result', 'replicas', 'input_format', 'input_config', 'input_topic', 'output_topic', 'limit', 'output_upper']
+        fields = ['model_result', 'replicas', 'input_format', 'input_config', 'input_topic', 'output_topic', 'limit', 'output_upper', 'token', 'external_host']
 
     def create(self, validated_data):
         """Creates a new inference, associated it with the result"""
@@ -189,4 +189,4 @@ class InferenceSerializer(serializers.ModelSerializer):
     
     class Meta:
         model = Inference
-        fields = ['id', 'model_result', 'replicas', 'input_format', 'input_config', 'input_topic', 'output_topic', 'time', 'status', 'status_changed', 'limit', 'output_upper']
+        fields = ['id', 'model_result', 'replicas', 'input_format', 'input_config', 'input_topic', 'output_topic', 'time', 'status', 'status_changed', 'limit', 'output_upper', 'token', 'external_host']

--- a/backend/automl/views.py
+++ b/backend/automl/views.py
@@ -78,6 +78,31 @@ def parse_kwargs_fit(kwargs_fit):
     
     return json.dumps(dic)
 
+def kubernetes_config( token=None, external_host=None ):
+    """ Get Kubernetes configuration.
+        You can provide a token and the external host IP 
+        to access a external Kubernetes cluster. If one
+        of them is not provided the configuration returned
+        will be for your local machine.
+
+        Parameters:
+            str: token 
+            str: external_host (e.g. "https://192.168.65.3:6443")
+
+        Return:
+            Kubernetes API instance
+    """
+    aConfiguration = client.Configuration()
+    if token is not None and \
+        external_host is not None:
+
+        aConfiguration.host = external_host 
+        aConfiguration.verify_ssl = False
+        aConfiguration.api_key = { "authorization": "Bearer " + token }
+    aApiClient = client.ApiClient( aConfiguration )
+    api_instance = client.CoreV1Api( aApiClient )
+    return api_instance
+
 def deploy( manifest, token=None, external_host=None ):
     """ Make a deployment according to the manifest.
         You can also provide an external host and its token
@@ -92,15 +117,9 @@ def deploy( manifest, token=None, external_host=None ):
         Return:
             Response of Kubernetes Cluster
     """
-    aConfiguration = client.Configuration()
-    if token is not None and \
-        external_host is not None:
-        aConfiguration.host = external_host 
-        aConfiguration.verify_ssl = False
-        aConfiguration.api_key = { "authorization": "Bearer " + token }
-    aApiClient = client.ApiClient(aConfiguration)
-    api_instance = client.CoreV1Api(aApiClient)
-    resp = api_instance.create_namespaced_replication_controller(body=manifest, namespace='default') # create_namespaced_deployment
+    api_instance = kubernetes_config( token=token, external_host=external_host )
+    # create_namespaced_deployment
+    resp = api_instance.create_namespaced_replication_controller( body=manifest, namespace='default' ) 
     return resp
 
 class ModelList(generics.ListCreateAPIView):

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,4 @@
-tensorflow==2.4.0 # 2.1.0 for Raspberry
+# tensorflow==2.2.0 # 2.1.0 for Raspberry
 django==3.0.7
 djangorestframework==3.11.0
 django-cors-headers==3.2.1

--- a/frontend/src/app/inference-list/inference-list.component.html
+++ b/frontend/src/app/inference-list/inference-list.component.html
@@ -27,6 +27,11 @@
           <mat-cell *matCellDef="let element" title="{{element.replicas}}">{{ element.replicas}} </mat-cell>
         </ng-container>
 
+        <ng-container matColumnDef="external_host">
+          <mat-header-cell *matHeaderCellDef>Host</mat-header-cell>
+          <mat-cell *matCellDef="let element" title="{{element.external_host}}">{{ element.external_host}} </mat-cell>
+        </ng-container>
+
         <ng-container matColumnDef="input_topic">
           <mat-header-cell *matHeaderCellDef> Kafka input topic </mat-header-cell>
           <mat-cell *matCellDef="let element" title="{{element.input_topic}}">{{ element.input_topic}} </mat-cell>

--- a/frontend/src/app/inference-list/inference-list.component.ts
+++ b/frontend/src/app/inference-list/inference-list.component.ts
@@ -13,7 +13,7 @@ import { ActivatedRoute } from '@angular/router';
 })
 export class InferenceListComponent implements OnInit {
 
-  displayedColumns = ['id',  'model_result', 'replicas', 'input_format', 'input_config', 
+  displayedColumns = ['id',  'model_result', 'replicas', 'input_format', 'input_config', 'external_host',
   'input_topic', 'output_topic', 'output_upper', 'limit', 'time', 'status', 'manage'];
 
   inferences: JSON[];

--- a/frontend/src/app/inference-view/inference-view.component.html
+++ b/frontend/src/app/inference-view/inference-view.component.html
@@ -33,7 +33,7 @@
 
       <mat-form-field class="full-width">
       <mat-label>Kubernetes Cluster Host</mat-label>
-        <input matInput placeholder="External Host"  name="external_host"  #nameRef="ngModel" [ngModel]="inference.external_host">
+        <input matInput placeholder="External Host (e.g. https://192.168.65.3:6443)"  name="external_host"  #nameRef="ngModel" [ngModel]="inference.external_host">
       </mat-form-field>
 
       <mat-form-field class="full-width">

--- a/frontend/src/app/inference-view/inference-view.component.html
+++ b/frontend/src/app/inference-view/inference-view.component.html
@@ -31,6 +31,16 @@
         <input matInput required placeholder="ouput_topic"  name="output_topic"  #nameRef="ngModel" [ngModel]="inference.output_topic">
       </mat-form-field>
 
+      <mat-form-field class="full-width">
+      <mat-label>Kubernetes Cluster Host</mat-label>
+        <input matInput placeholder="External Host"  name="external_host"  #nameRef="ngModel" [ngModel]="inference.external_host">
+      </mat-form-field>
+
+      <mat-form-field class="full-width">
+      <mat-label>Kubernetes Cluster Token</mat-label>
+        <input matInput placeholder="Token"  name="token"  #nameRef="ngModel" [ngModel]="inference.token">
+      </mat-form-field>
+
       <mat-form-field *ngIf="distributed" class="full-width">
         <mat-label>Kafka output topic for upper model</mat-label>
           <input matInput required placeholder="ouput_upper"  name="output_upper"  #nameRef="ngModel" [ngModel]="inference.output_upper">

--- a/frontend/src/app/shared/inference.model.ts
+++ b/frontend/src/app/shared/inference.model.ts
@@ -5,6 +5,8 @@ export class Inference {
     input_config: string;
     input_topic: string;
     output_topic: string;
+    token: string;
+    external_host: string;
     limit: number;
     output_upper: string;
 }

--- a/model_inference/requirements.txt
+++ b/model_inference/requirements.txt
@@ -1,3 +1,3 @@
-tensorflow==2.4.0 # no need to install this since it is in the base image
+tensorflow==2.2.0 # no need to install this since it is in the base image
 tensorflow-io==0.13.0 # tfio.experimental.serialization.decode_avro is included from 0.12.0 version
 kafka-python==2.0.1 


### PR DESCRIPTION
- [X] Going back to Tensorflow 2.2.0 to avoid dependence incompatibilities.
- [x] Deployment of models to external Kubernetes clusters.
- [x] Remove these models from external Kubernetes clusters.