### PR TITLE
Clean Dockerfiles using their WORKDIR

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -11,11 +11,11 @@ ENV PYTHONUNBUFFERED 1
 
 # install dependencies
 RUN pip install --upgrade pip
-COPY ./requirements.txt /usr/src/app/requirements.txt
+COPY ./requirements.txt ./requirements.txt
 RUN pip install -r requirements.txt
 
 # copy project
-COPY . /usr/src/app/
+COPY . .
 
 EXPOSE 8000
 

--- a/kafka_control_logger/Dockerfile
+++ b/kafka_control_logger/Dockerfile
@@ -9,11 +9,11 @@ ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 
 # install dependencies
-COPY ./requirements.txt /usr/src/app/requirements.txt
+COPY ./requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
 # copy project
-COPY . /usr/src/app/
+COPY . .
 
 RUN chmod +x ./start.sh
 CMD ["./start.sh"]

--- a/mlcode_executor/pthexecutor/Dockerfile
+++ b/mlcode_executor/pthexecutor/Dockerfile
@@ -13,11 +13,11 @@ ENV PYTHONUNBUFFERED 1
 
 # install dependencies
 RUN pip install --upgrade pip
-COPY ./requirements.txt /usr/src/app/requirements.txt
+COPY ./requirements.txt ./requirements.txt
 RUN pip install -r requirements.txt
 
 # copy project
-COPY . /usr/src/app/
+COPY . .
 
 EXPOSE 8002
 

--- a/mlcode_executor/tfexecutor/Dockerfile
+++ b/mlcode_executor/tfexecutor/Dockerfile
@@ -13,11 +13,11 @@ ENV PYTHONUNBUFFERED 1
 
 # install dependencies
 RUN pip install --upgrade pip
-COPY ./requirements.txt /usr/src/app/requirements.txt
+COPY ./requirements.txt ./requirements.txt
 RUN pip install -r requirements.txt
 
 # copy project
-COPY . /usr/src/app/
+COPY . .
 
 EXPOSE 8001
 

--- a/model_inference/pytorch/Dockerfile
+++ b/model_inference/pytorch/Dockerfile
@@ -13,11 +13,11 @@ ENV PYTHONUNBUFFERED 1
 
 # install dependencies
 RUN pip install --upgrade pip
-COPY ./requirements.txt /usr/src/app/requirements.txt
+COPY ./requirements.txt ./requirements.txt
 RUN pip install -r requirements.txt
 
 # copy project
-COPY . /usr/src/app/
+COPY . .
 
 RUN chmod +x ./start.sh
 CMD ["./start.sh"]

--- a/model_inference/tensorflow/Dockerfile
+++ b/model_inference/tensorflow/Dockerfile
@@ -13,11 +13,11 @@ ENV PYTHONUNBUFFERED 1
 
 # install dependencies
 RUN pip install --upgrade pip
-COPY ./requirements.txt /usr/src/app/requirements.txt
+COPY ./requirements.txt ./requirements.txt
 RUN pip install -r requirements.txt
 
 # copy project
-COPY . /usr/src/app/
+COPY . .
 
 RUN chmod +x ./start.sh
 CMD ["./start.sh"]

--- a/model_training/pytorch/Dockerfile
+++ b/model_training/pytorch/Dockerfile
@@ -13,11 +13,11 @@ ENV PYTHONUNBUFFERED 1
 
 # install dependencies
 RUN pip install --upgrade pip
-COPY ./requirements.txt /usr/src/app/requirements.txt
+COPY ./requirements.txt ./requirements.txt
 RUN pip install -r requirements.txt
 
 # copy project
-COPY . /usr/src/app/
+COPY . .
 
 RUN chmod +x ./start.sh
 CMD ["./start.sh"]

--- a/model_training/tensorflow/Dockerfile
+++ b/model_training/tensorflow/Dockerfile
@@ -13,11 +13,11 @@ ENV PYTHONUNBUFFERED 1
 
 # install dependencies
 RUN pip install --upgrade pip
-COPY ./requirements.txt /usr/src/app/requirements.txt
+COPY ./requirements.txt ./requirements.txt
 RUN pip install -r requirements.txt
 
 # copy project
-COPY . /usr/src/app/
+COPY . .
 
 RUN chmod +x ./start.sh
 CMD ["./start.sh"]


### PR DESCRIPTION
When a `WORKDIR` line is defined in a Dockerfile then the "current directory" aka `.` will be the directory specified by `WORKDIR`, so there is no need to write `/usr/src/app` again

Reference: [https://docs.docker.com/engine/reference/builder/#workdir](https://docs.docker.com/engine/reference/builder/#workdir)